### PR TITLE
feat: Create ticket endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ REDIS_PORT=6379
 
 # Server config
 SERVER_PORT=8083
+ID_GEN_SERVER_URL=http://localhost:8085
 
 # ID gen server config
 ID_GEN_SERVER_PORT=8085

--- a/cmd/gen/main.go
+++ b/cmd/gen/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	// Handler
-	hdl := handler.New(repo, log)
+	hdl := handler.New(repo, log, cfg)
 
 	// Echo instance
 	e := echo.New()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	// Handler
-	hdl := handler.New(repo, log)
+	hdl := handler.New(repo, log, cfg)
 
 	// Echo instance
 	e := echo.New()
@@ -52,6 +52,11 @@ func main() {
 	ticketRouter.Add(http.MethodPost, "/book", hdl.Book)
 	ticketRouter.Add(http.MethodPost, "/reserve", hdl.Reserve)
 	ticketRouter.Add(http.MethodPost, "/cancel", hdl.Cancel)
+	ticketRouter.Add(http.MethodPost, "/create", hdl.Create)
+
+	apiV2 := e.Group("/api/v2")
+	ticketRouterV2 := apiV2.Group("/tickets")
+	ticketRouterV2.Add(http.MethodPost, "/create", hdl.CreateV2)
 
 	if err := e.Start(fmt.Sprintf(":%s", cfg.SERVER_PORT)); err != nil {
 		log.WithError(err).Error("failed to start server")

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,8 @@ type Config struct {
 	REDIS_PORT string `envconfig:"REDIS_PORT"`
 
 	// SERVER
-	SERVER_PORT string `envconfig:"SERVER_PORT"`
+	SERVER_PORT       string `envconfig:"SERVER_PORT"`
+	ID_GEN_SERVER_URL string `envconfig:"ID_GEN_SERVER_URL"`
 
 	// ID_GEN_SERVER
 	ID_GEN_SERVER_PORT string `envconfig:"ID_GEN_SERVER_PORT"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       - postgres
     depends_on:
       - postgres
-    command: "id-gen-server" 
+    command: "gen" 
     restart: always
 
   queue:

--- a/ent/migrate/migrations/20230301045813_create_admin_user.sql
+++ b/ent/migrate/migrations/20230301045813_create_admin_user.sql
@@ -1,0 +1,2 @@
+INSERT INTO users (id, name, email, phone, created_at, updated_at)
+		VALUES('9ac3a9be-b76f-11ed-afa1-0242ac120002', 'admin', 'admin@m.com', '011', now(), now());

--- a/ent/migrate/migrations/atlas.sum
+++ b/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:jGrE349sExN8HECdbt9JpFcr0SkfVzqmE3daEOsW1F8=
+h1:3ANhwRS2WTUVPnr88lOi3xOAHsDZ06SMN2tTHYQmeDI=
 20221222113951_create-table-transactions.sql h1:P+tR4VZEe0VcPRXmyf/+SBCk30JTd7M4vGADY0dmX8g=
 20221222115349_add-column-time.sql h1:klengbadutLHChoXDQ7f0Wg/99S9HCrPZ1B406RSY8o=
 20221222125419_add-created-at.sql h1:AvfvylPl4RWimi0ffzlLtPQkvXMCjJgC07Nf27okCBA=
@@ -7,3 +7,4 @@ h1:jGrE349sExN8HECdbt9JpFcr0SkfVzqmE3daEOsW1F8=
 20230115102626_update-optional-fields.sql h1:0YgDyir60/pXRKYg5tKLTwJkpSx7y3eU7P8j7alHZno=
 20230219100638_fix-typo.sql h1:WB4Z4kuFzL6oY+D8jOIiXtRi/AFNN2XEhHYoucF0ElA=
 20230221093254_create-table-create-ticket-logs.sql h1:hlCjT1MDJrEofpkIxVd2QN3qa9s/olzrOLB+gf6kFyc=
+20230301045813_create_admin_user.sql h1:CEv6CLG98ntcKIQBZtJwfb052GNWKxxpHxWQnZd7Ass=

--- a/internal/controller/spec.go
+++ b/internal/controller/spec.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"database-concurrency/config"
 	"database-concurrency/internal/controller/gen"
 	"database-concurrency/internal/controller/ticket"
 	"database-concurrency/internal/controller/transaction"
@@ -17,10 +18,10 @@ type Controller interface {
 }
 
 // New is used to create new controller
-func New(repo repository.Repository, log *logrus.Logger) Controller {
+func New(repo repository.Repository, log *logrus.Logger, cfg config.Config) Controller {
 	return controller{
 		transactionCtrl: transaction.New(repo, log),
-		ticketCtrl:      ticket.New(repo, log),
+		ticketCtrl:      ticket.New(repo, log, cfg),
 		genCtrl:         gen.New(repo, log),
 	}
 }

--- a/internal/controller/ticket/spec.go
+++ b/internal/controller/ticket/spec.go
@@ -2,6 +2,7 @@ package ticket
 
 import (
 	"context"
+	"database-concurrency/config"
 	"database-concurrency/ent"
 	"database-concurrency/internal/controller/utils"
 	"database-concurrency/internal/repository"
@@ -16,11 +17,16 @@ type Controller interface {
 	Reserve(ctx context.Context, ticketID, userID uuid.UUID) (*ent.Ticket, error)
 	// Cancel the ticket
 	Cancel(ctx context.Context, ticketID, userID uuid.UUID) (*ent.Ticket, error)
+	// Create the ticket
+	Create(ctx context.Context) (*ent.Ticket, error)
+	// CreateV2 Create the ticket from unique id
+	CreateV2(ctx context.Context, unique_id uuid.UUID) (*ent.Ticket, error)
 }
 
-func New(repo repository.Repository, log *logrus.Logger) Controller {
+func New(repo repository.Repository, log *logrus.Logger, cfg config.Config) Controller {
 	return ticket{
 		repo: repo,
 		log:  log,
+		cfg:  cfg,
 	}
 }

--- a/internal/handler/payload/ticket.go
+++ b/internal/handler/payload/ticket.go
@@ -40,3 +40,11 @@ type GenTicketIDRequest struct {
 type GenTicketIDResponse struct {
 	TicketID string `json:"ticket_id"`
 }
+
+type CreateTicketRequest struct {
+	UniqueID uuid.UUID `json:"unique_id"`
+}
+
+type CreateTicketResponse struct {
+	Ticket *ent.Ticket `json:"ticket"`
+}

--- a/internal/handler/spec.go
+++ b/internal/handler/spec.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"database-concurrency/config"
 	"database-concurrency/internal/controller"
 	"database-concurrency/internal/repository"
 
@@ -16,14 +17,19 @@ type Handler interface {
 	Reserve(ctx echo.Context) error
 	// Cancel cancel a ticket
 	Cancel(ctx echo.Context) error
+	// Create create a ticket
+	Create(ctx echo.Context) error
+
+	// CreateV2 create a ticket from a unique id
+	CreateV2(ctx echo.Context) error
 
 	// GenTicketID gen new ticket id for creating ticket, id gen API ONLY
 	GenTicketID(ctx echo.Context) error
 }
 
 // New is used to create new controller
-func New(repo repository.Repository, log *logrus.Logger) Handler {
+func New(repo repository.Repository, log *logrus.Logger, cfg config.Config) Handler {
 	return handler{
-		ctrl: controller.New(repo, log),
+		ctrl: controller.New(repo, log, cfg),
 	}
 }

--- a/internal/handler/ticket.go
+++ b/internal/handler/ticket.go
@@ -78,3 +78,34 @@ func (h handler) Cancel(ctx echo.Context) error {
 		Ticket: result,
 	})
 }
+
+func (h handler) Create(ctx echo.Context) error {
+	result, err := h.ctrl.TicketCtrl().Create(ctx.Request().Context())
+	if err != nil {
+		return echo.NewHTTPError(500, err.Error())
+	}
+
+	return ctx.JSON(200, payload.CreateTicketResponse{
+		Ticket: result,
+	})
+}
+
+func (h handler) CreateV2(ctx echo.Context) error {
+	var req payload.CreateTicketRequest
+	if err := json.NewDecoder(ctx.Request().Body).Decode(&req); err != nil {
+		return echo.NewHTTPError(400, err.Error())
+	}
+
+	if req.UniqueID.String() == uuid.Nil.String() {
+		return echo.NewHTTPError(400, "unique_id is required")
+	}
+
+	result, err := h.ctrl.TicketCtrl().CreateV2(ctx.Request().Context(), req.UniqueID)
+	if err != nil {
+		return echo.NewHTTPError(500, err.Error())
+	}
+
+	return ctx.JSON(200, payload.CreateTicketResponse{
+		Ticket: result,
+	})
+}

--- a/internal/repository/ticket/pg.go
+++ b/internal/repository/ticket/pg.go
@@ -33,3 +33,13 @@ func (pg pg) Update(ctx context.Context, ticket *ent.Ticket) (*ent.Ticket, error
 		SetVersions(ticket.Versions).
 		Save(ctx)
 }
+
+// Update updates a ticket
+func (pg pg) Create(ctx context.Context, ticket *ent.Ticket) (*ent.Ticket, error) {
+	return pg.client.Create().
+		SetID(ticket.ID).
+		SetUserID(ticket.UserID).
+		SetStatus(ticket.Status).
+		SetVersions(ticket.Versions).
+		Save(ctx)
+}

--- a/internal/repository/ticket/repo.go
+++ b/internal/repository/ticket/repo.go
@@ -12,6 +12,7 @@ type Repository interface {
 	One(ctx context.Context, id uuid.UUID) (*ent.Ticket, error)
 	OneForUpdate(ctx context.Context, id uuid.UUID) (*ent.Ticket, error)
 	Update(ctx context.Context, ticket *ent.Ticket) (*ent.Ticket, error)
+	Create(ctx context.Context, ticket *ent.Ticket) (*ent.Ticket, error)
 }
 
 // NewPGRepo is used to generate new Ticket repository


### PR DESCRIPTION
**Descriptions**
- Add endpoints for create ticket scenario, `api/v1/ticket/create` and `api/v2/ticket/create`, `v2` required `unique_id`.

**Changes**
- Add endpoints for ticket's `Create`, and `CreateV2`
- Update handler to receive `cfg` as input
- Minor changes to docker compose file for `gen` server
- Add migration file to init `admin` user to create ticket