### PR TITLE
feat: bfs algo shortest path

### DIFF
--- a/internal/transducer/booking_test.go
+++ b/internal/transducer/booking_test.go
@@ -53,3 +53,12 @@ func TestBookingGetFloydWarshallPaths(t *testing.T) {
 		}
 	}
 }
+
+func TestBookingGetShortestPaths(t *testing.T) {
+	characterConfig := CreateConfig().SetState(Idle)
+	characterTransducer := NewBookingTransducer(characterConfig)
+
+	paths := characterTransducer.GetShortestPaths(Idle)
+
+	fmt.Println(paths)
+}

--- a/internal/transducer/booking_test.go
+++ b/internal/transducer/booking_test.go
@@ -28,11 +28,11 @@ func TestRehearseBookingTransducer(t *testing.T) {
 	}
 }
 
-func TestBookingShortestPaths(t *testing.T) {
+func TestBookingGetFloydWarshallPaths(t *testing.T) {
 	characterConfig := CreateConfig().SetState(Idle)
 	characterTransducer := NewBookingTransducer(characterConfig)
 
-	paths, edges := characterTransducer.GetShortestPaths()
+	paths, edges := characterTransducer.GetFloydWarshallPaths()
 	currentState := graph.Vertex(Idle)
 
 	for _, path := range paths {

--- a/internal/transducer/graph/floyd_warshall.go
+++ b/internal/transducer/graph/floyd_warshall.go
@@ -1,0 +1,38 @@
+package graph
+
+func FloydWarshall(g Graph) (dist map[Vertex]map[Vertex]float64, next map[Vertex]map[Vertex]*Vertex) {
+	vertexes := g.Vertices()
+	dist = make(map[Vertex]map[Vertex]float64)
+	next = make(map[Vertex]map[Vertex]*Vertex)
+
+	for _, u := range vertexes {
+		dist[u] = make(map[Vertex]float64)
+		next[u] = make(map[Vertex]*Vertex)
+
+		for _, v := range vertexes {
+			dist[u][v] = Infinity
+		}
+
+		dist[u][u] = 0
+
+		for _, v := range g.Neighbors(u) {
+			v := v
+			dist[u][v] = g.Weight(u, v)
+			next[u][v] = &v
+		}
+	}
+
+	for _, k := range vertexes {
+		for _, i := range vertexes {
+			for _, j := range vertexes {
+				if dist[i][k] < Infinity && dist[k][j] < Infinity {
+					if dist[i][j] > dist[i][k]+dist[k][j] {
+						dist[i][j] = dist[i][k] + dist[k][j]
+						next[i][j] = next[i][k]
+					}
+				}
+			}
+		}
+	}
+	return dist, next
+}

--- a/internal/transducer/graph/graph.go
+++ b/internal/transducer/graph/graph.go
@@ -8,6 +8,8 @@ type GraphSpec interface {
 	Weight(u, v Vertex) float64
 }
 
+var Infinity = math.Inf(0)
+
 type Vertex string
 
 type Graph struct {
@@ -39,42 +41,6 @@ func (g Graph) Neighbors(v Vertex) (vs []Vertex) {
 
 func (g Graph) Weight(u, v Vertex) float64 {
 	return g.edges[u][v]
-}
-
-var Infinity = math.Inf(0)
-
-func FloydWarshall(g Graph) (dist map[Vertex]map[Vertex]float64, next map[Vertex]map[Vertex]*Vertex) {
-	vertexes := g.Vertices()
-	dist = make(map[Vertex]map[Vertex]float64)
-	next = make(map[Vertex]map[Vertex]*Vertex)
-
-	for _, u := range vertexes {
-		dist[u] = make(map[Vertex]float64)
-		next[u] = make(map[Vertex]*Vertex)
-		for _, v := range vertexes {
-			dist[u][v] = Infinity
-		}
-		dist[u][u] = 0
-		for _, v := range g.Neighbors(u) {
-			v := v
-			dist[u][v] = g.Weight(u, v)
-			next[u][v] = &v
-		}
-	}
-
-	for _, k := range vertexes {
-		for _, i := range vertexes {
-			for _, j := range vertexes {
-				if dist[i][k] < Infinity && dist[k][j] < Infinity {
-					if dist[i][j] > dist[i][k]+dist[k][j] {
-						dist[i][j] = dist[i][k] + dist[k][j]
-						next[i][j] = next[i][k]
-					}
-				}
-			}
-		}
-	}
-	return dist, next
 }
 
 func GetPaths(u Vertex, v Vertex, next map[Vertex]map[Vertex]*Vertex) (paths []Vertex) {

--- a/internal/transducer/graph/ring_buffer.go
+++ b/internal/transducer/graph/ring_buffer.go
@@ -1,0 +1,77 @@
+package graph
+
+const minQueueLen = 16
+
+type Queue struct {
+	buf               []interface{}
+	head, tail, count int
+}
+
+func NewRingBuffer() *Queue {
+	return &Queue{
+		buf: make([]interface{}, minQueueLen),
+	}
+}
+
+func (q *Queue) Length() int {
+	return q.count
+}
+
+func (q *Queue) resize() {
+	newBuf := make([]interface{}, q.count<<1)
+
+	if q.tail > q.head {
+		copy(newBuf, q.buf[q.head:q.tail])
+	} else {
+		n := copy(newBuf, q.buf[q.head:])
+		copy(newBuf[n:], q.buf[:q.tail])
+	}
+
+	q.head = 0
+	q.tail = q.count
+	q.buf = newBuf
+}
+
+func (q *Queue) Add(elem interface{}) {
+	if q.count == len(q.buf) {
+		q.resize()
+	}
+
+	q.buf[q.tail] = elem
+
+	q.tail = (q.tail + 1) & (len(q.buf) - 1)
+	q.count++
+}
+
+func (q *Queue) Peek() interface{} {
+	if q.count <= 0 {
+		panic("queue: Peek() called on empty queue")
+	}
+	return q.buf[q.head]
+}
+
+func (q *Queue) Get(i int) interface{} {
+	if i < 0 {
+		i += q.count
+	}
+	if i < 0 || i >= q.count {
+		panic("queue: Get() called with index out of range")
+	}
+	return q.buf[(q.head+i)&(len(q.buf)-1)]
+}
+
+func (q *Queue) Remove() interface{} {
+	if q.count <= 0 {
+		panic("queue: Remove() called on empty queue")
+	}
+	ret := q.buf[q.head]
+	q.buf[q.head] = nil
+
+	q.head = (q.head + 1) & (len(q.buf) - 1)
+	q.count--
+
+	if len(q.buf) > minQueueLen && (q.count<<2) == len(q.buf) {
+		q.resize()
+	}
+	return ret
+}

--- a/internal/transducer/transducer.go
+++ b/internal/transducer/transducer.go
@@ -145,11 +145,11 @@ func (t *Transducer) ToDiGraph() string {
 	return digraph
 }
 
-func (t *Transducer) GetShortestPaths() ([][]graph.Vertex, map[graph.Vertex]map[graph.Vertex]Input) {
+func (t *Transducer) GetFloydWarshallPaths() ([][]graph.Vertex, map[graph.Vertex]map[graph.Vertex]Input) {
 	vertexes := []graph.Vertex{}
 	edges := make(map[graph.Vertex]map[graph.Vertex]Input)
 	edgeWeights := make(map[graph.Vertex]map[graph.Vertex]float64)
-	weight := 0.0
+	weight := len(t.TransitionTable)
 
 	for stateInputTuple, f := range t.TransitionTable {
 		state := graph.Vertex(stateInputTuple.State)
@@ -168,13 +168,13 @@ func (t *Transducer) GetShortestPaths() ([][]graph.Vertex, map[graph.Vertex]map[
 		_, exists = edgeWeights[state]
 		if !exists {
 			edgeWeights[state] = make(map[graph.Vertex]float64)
-			weight += 1
+			weight -= 1
 		}
 		_, exists = edgeWeights[state][nextState]
 		if !exists {
-			weight += 1
+			weight -= 1
 		}
-		edgeWeights[state][nextState] = weight
+		edgeWeights[state][nextState] = float64(weight)
 	}
 
 	g := graph.NewGraph(vertexes, edgeWeights)

--- a/internal/transducer/transducer.go
+++ b/internal/transducer/transducer.go
@@ -229,7 +229,7 @@ func (t *Transducer) GetShortestPaths(root State) map[State][]StateInputTuple {
 				stateQueue.Add(nextState)
 			}
 
-			if nextState == queuedState {
+			if nextState == queuedState && nextState != root {
 				pathQueue.Add(state)
 				stateMap[queuedState] = append(stateMap[queuedState], StateInputTuple{State: state, Input: input})
 			}
@@ -250,7 +250,7 @@ func (t *Transducer) GetShortestPaths(root State) map[State][]StateInputTuple {
 				input := tuple.Input
 				nextState := f().GetState()
 
-				if nextState == queuedPath {
+				if nextState == queuedPath && nextState != root {
 					pathQueue.Add(state)
 					stateMap[queuedState] = append(stateMap[queuedState], StateInputTuple{State: state, Input: input})
 				}


### PR DESCRIPTION
**What does this PR do?:**
- [x] Implements a [ring-buffer queue](https://github.com/eapache/queue) for BFS
- [x] Move Floyd Warshall files and reformat
- [x] Rework shortest paths with nested ring-buffer BFS

**Target Shortest Paths:**

ROOT IDLE:
```
map[
	Booked:[
		{Reserved Book}
		{Idle Reserve}
	]
	Cancelled:[
		{Reserved Cancel}
		{Idle Reserve}
	]
	CheckedIn:[
		{Booked CheckIn}
		{Reserved Book}
		{Idle Reserve}
	]
	CheckedOut:[
		{CheckedIn CheckOut}
		{Booked CheckIn}
		{Reserved Book}
		{Idle Reserve}
	]
	Idle:[]
	Reserved:[
		{Idle Reserve}
	]
]
```

ROOT RESERVED:
```
map[
	Booked:[
		{Reserved Book}
	]
	
	Cancelled:[
		{Reserved Cancel}
	]

	CheckedIn:[
		{Booked CheckIn}
		{Reserved Book}
	]

	CheckedOut:[
		{CheckedIn CheckOut}
		{Booked CheckIn}
		{Reserved Book}
	]

	Reserved:[]
]
```